### PR TITLE
fix: address review findings (categorical detection, bitset safety, API)

### DIFF
--- a/src/openboost/__init__.py
+++ b/src/openboost/__init__.py
@@ -96,7 +96,14 @@ Tree = TreeStructure  # Alias for backward compatibility
 # =============================================================================
 # Backend Control
 # =============================================================================
-from ._backends import backend_context, get_backend, is_cpu, is_cuda, set_backend
+from ._backends import (
+    backend_context,
+    clear_tree_workspace_cache,
+    get_backend,
+    is_cpu,
+    is_cuda,
+    set_backend,
+)
 
 # =============================================================================
 # Callbacks (Phase 13)
@@ -433,6 +440,7 @@ __all__ = [
     "predict_ensemble",
     # Backend
     "backend_context",
+    "clear_tree_workspace_cache",
     "get_backend",
     "set_backend",
     # Persistence

--- a/src/openboost/_array.py
+++ b/src/openboost/_array.py
@@ -243,14 +243,18 @@ def array(
         if idx < 0 or idx >= n_features:
             raise ValueError(f"categorical_features index {idx} out of range [0, {n_features})")
 
-    # Auto-detect string/object columns as categorical
+    # Auto-detect string/object columns as categorical.
+    # NOTE: test via dtype.kind, not `is object` — a numpy/pandas dtype is a
+    # distinct object from the builtin `object` (np.dtype('O') is object -> False),
+    # so an identity check silently misses string/object columns. dtype.kind is
+    # 'O' for object, 'U'/'S' for fixed-width unicode/bytes strings.
     if hasattr(X, 'dtypes'):
         # DataFrame: check each column's dtype
         for i, dtype in enumerate(X.dtypes):
-            if dtype is object or hasattr(dtype, 'categories'):
+            if getattr(dtype, 'kind', '') in ('O', 'U', 'S') or hasattr(dtype, 'categories'):
                 categorical_set.add(i)
-    elif X_np.dtype is np.dtype(object):
-        # Object array: check which columns are non-numeric
+    elif X_np.dtype.kind in ('O', 'U', 'S'):
+        # Object/string array: check which columns are non-numeric
         for i in range(n_features):
             col = X_np[:, i]
             try:

--- a/src/openboost/_backends/__init__.py
+++ b/src/openboost/_backends/__init__.py
@@ -80,10 +80,30 @@ def is_cpu() -> bool:
     return get_backend() == "cpu"
 
 
+def clear_tree_workspace_cache() -> None:
+    """Free cached GPU tree-building workspace arrays (no-op on CPU).
+
+    Call this between training runs that use different data shapes to avoid
+    holding onto stale GPU allocations. Safe to call on CPU-only installs,
+    where it does nothing.
+    """
+    if get_backend() != "cuda":
+        return
+    from ._cuda import clear_tree_workspace_cache as _clear
+    _clear()
+
+
 class backend_context:
     """Context manager for temporarily switching the compute backend.
 
-    Restores the previous backend on exit, even if an exception occurs.
+    Restores the previous backend on exit, even if an exception occurs. If no
+    backend had been resolved yet on entry, exit restores the unresolved state
+    so the backend is auto-detected again on next use.
+
+    Note:
+        This mutates the **process-global** backend, not a thread-local one.
+        It is therefore not safe to use concurrently from multiple threads —
+        one thread's context will affect every other thread.
 
     Example::
 
@@ -103,6 +123,9 @@ class backend_context:
 
     def __exit__(self, *exc: object) -> None:
         global _BACKEND
+        # Restore by direct assignment (set_backend only writes the global and
+        # rejects None; direct assignment also lets us restore the
+        # "unresolved -> auto-detect" state when _previous is None).
         with _BACKEND_LOCK:
             _BACKEND = self._previous
 

--- a/src/openboost/_backends/_cpu.py
+++ b/src/openboost/_backends/_cpu.py
@@ -555,11 +555,15 @@ def _find_best_categorical_split(
                     best_split = i + 1
                     best_miss_left = True
     
-    # Build bitmask: categories in sorted order before split_point go left
+    # Build bitmask: categories in sorted order before split_point go left.
+    # cat_bitset is 64-bit, so category bins >= 64 cannot be represented; they
+    # are never placed in the left set here and are always routed right at
+    # partition/predict time (kept consistent across CPU and GPU).
     cat_bitset = 0
     for i in range(best_split):
         cat = sorted_cats[i]
-        cat_bitset |= (1 << cat)
+        if cat < 64:
+            cat_bitset |= (1 << cat)
     
     return best_gain, best_split, cat_bitset, best_miss_left
 
@@ -711,9 +715,13 @@ def _predict_cpu_with_categorical(
             if bin_value == MISSING_BIN:
                 node = tree_left[node] if tree_missing_left[node] else tree_right[node]
             elif is_categorical_split[node]:
-                # Categorical split: use bitmask
+                # Categorical split: use bitmask. Bins >= 64 are not
+                # representable in the 64-bit bitset and always go right.
                 bitset = cat_bitsets[node]
-                node = tree_left[node] if np.int64(1) << bin_value & bitset else tree_right[node]
+                goes_left = False
+                if bin_value < 64:
+                    goes_left = ((np.int64(1) << bin_value) & bitset) != 0
+                node = tree_left[node] if goes_left else tree_right[node]
             else:
                 # Numeric split: use threshold
                 threshold = tree_thresholds[node]

--- a/src/openboost/_backends/_cuda.py
+++ b/src/openboost/_backends/_cuda.py
@@ -1275,9 +1275,13 @@ def _predict_with_categorical_kernel(
         if bin_value == 255:  # MISSING_BIN
             node = tree_left[node] if tree_missing_left[node] else tree_right[node]
         elif is_categorical_split[node]:
-            # Categorical split: use bitmask
+            # Categorical split: use bitmask. Bins >= 64 are not representable
+            # in the 64-bit bitset and always go right.
             bitset = cat_bitsets[node]
-            node = tree_left[node] if int64(1) << bin_value & bitset else tree_right[node]
+            goes_left = False
+            if bin_value < 64:
+                goes_left = ((int64(1) << bin_value) & bitset) != 0
+            node = tree_left[node] if goes_left else tree_right[node]
         else:
             # Numeric split: use threshold
             threshold = tree_thresholds[node]
@@ -1648,11 +1652,14 @@ def _find_best_categorical_split_kernel(
                         best_split = i + 1
                         best_miss_left_cat = True
         
-        # Build bitmask: categories before split_point go left
+        # Build bitmask: categories before split_point go left.
+        # cat_bitset is 64-bit; category bins >= 64 cannot be represented and
+        # are always routed right (consistent with CPU split-finding/predict).
         cat_bitset = int64(0)
         for i in range(best_split):
             cat = sorted_cats[i]
-            cat_bitset |= (int64(1) << cat)
+            if cat < 64:
+                cat_bitset |= (int64(1) << cat)
         
         best_gains[feature_idx] = best_gain_cat
         best_thresholds[feature_idx] = best_split

--- a/src/openboost/_callbacks.py
+++ b/src/openboost/_callbacks.py
@@ -23,6 +23,7 @@ Example:
 from __future__ import annotations
 
 import copy
+import warnings
 from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -418,3 +419,25 @@ class CallbackManager:
         """Call on_train_end for all callbacks."""
         for cb in self.callbacks:
             cb.on_train_end(state)
+
+
+def warn_if_early_stopping_without_eval_set(
+    callbacks: list[Callback] | None,
+    eval_set: object | None,
+) -> None:
+    """Warn if an ``EarlyStopping`` callback is set but no ``eval_set`` is given.
+
+    Early stopping needs a validation set to compute the monitored metric, so
+    without ``eval_set`` it silently has no effect. Shared by all model fit
+    paths to keep the message and behavior consistent.
+    """
+    if eval_set is not None or not callbacks:
+        return
+    if any(isinstance(cb, EarlyStopping) for cb in callbacks):
+        warnings.warn(
+            "EarlyStopping callback provided but eval_set is None. "
+            "Early stopping requires eval_set to compute validation "
+            "loss and will have no effect.",
+            UserWarning,
+            stacklevel=3,
+        )

--- a/src/openboost/_core/_growth.py
+++ b/src/openboost/_core/_growth.py
@@ -317,9 +317,11 @@ class TreeStructure:
                         node = self.right_children[node]
                 # Phase 14.3: Handle categorical splits
                 elif has_categorical and self.is_categorical_split[node]:
-                    # Check bitmask membership: bit[bin_value] == 1 means go left
+                    # Check bitmask membership: bit[bin_value] == 1 means go left.
+                    # Bins >= 64 are not representable in the 64-bit bitset and
+                    # always go right (consistent with CPU/GPU kernels).
                     bitset = self.cat_bitsets[node]
-                    goes_left = (bitset >> bin_value) & 1
+                    goes_left = ((bitset >> bin_value) & 1) if bin_value < 64 else 0
                     node = self.left_children[node] if goes_left else self.right_children[node]
                 # Standard ordinal split
                 elif bin_value <= threshold:

--- a/src/openboost/_models/_boosting.py
+++ b/src/openboost/_models/_boosting.py
@@ -23,7 +23,12 @@ import numpy as np
 
 from .._array import BinnedArray, array
 from .._backends import is_cuda
-from .._callbacks import Callback, CallbackManager, EarlyStopping, TrainingState
+from .._callbacks import (
+    Callback,
+    CallbackManager,
+    TrainingState,
+    warn_if_early_stopping_without_eval_set,
+)
 from .._core._growth import TreeStructure
 from .._core._tree import fit_tree
 from .._loss import LossFunction, compute_loss_value, get_loss_function
@@ -599,18 +604,7 @@ class GradientBoosting(PersistenceMixin):
         state = TrainingState(model=self, n_rounds=self.n_trees)
         cb_manager.on_train_begin(state)
 
-        # Warn if EarlyStopping is used without eval_set
-        if eval_set is None:
-            for cb in (callbacks or []):
-                if isinstance(cb, EarlyStopping):
-                    warnings.warn(
-                        "EarlyStopping callback provided but eval_set is None. "
-                        "Early stopping requires eval_set to compute validation "
-                        "loss and will have no effect.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    break
+        warn_if_early_stopping_without_eval_set(callbacks, eval_set)
 
         # Move y to GPU
         y_gpu = cuda.to_device(y)
@@ -921,18 +915,7 @@ class GradientBoosting(PersistenceMixin):
         state = TrainingState(model=self, n_rounds=self.n_trees)
         cb_manager.on_train_begin(state)
 
-        # Warn if EarlyStopping is used without eval_set
-        if eval_set is None:
-            for cb in (callbacks or []):
-                if isinstance(cb, EarlyStopping):
-                    warnings.warn(
-                        "EarlyStopping callback provided but eval_set is None. "
-                        "Early stopping requires eval_set to compute validation "
-                        "loss and will have no effect.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    break
+        warn_if_early_stopping_without_eval_set(callbacks, eval_set)
 
         # Initialize predictions with base score
         base = getattr(self, 'base_score_', np.float32(0.0))
@@ -1298,17 +1281,7 @@ class MultiClassGradientBoosting(PersistenceMixin):
         cb_manager.on_train_begin(state)
 
         eval_set = validate_eval_set(eval_set, self.X_binned_.n_features)
-        if eval_set is None:
-            for cb in (callbacks or []):
-                if isinstance(cb, EarlyStopping):
-                    warnings.warn(
-                        "EarlyStopping callback provided but eval_set is None. "
-                        "Early stopping requires eval_set to compute validation "
-                        "loss and will have no effect.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    break
+        warn_if_early_stopping_without_eval_set(callbacks, eval_set)
 
         # Determine sampling strategy (Phase 17)
         use_goss = self.subsample_strategy == 'goss'

--- a/src/openboost/_models/_dart.py
+++ b/src/openboost/_models/_dart.py
@@ -20,7 +20,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from .._array import BinnedArray, array
-from .._callbacks import Callback, CallbackManager, EarlyStopping, TrainingState
+from .._callbacks import (
+    Callback,
+    CallbackManager,
+    TrainingState,
+    warn_if_early_stopping_without_eval_set,
+)
 from .._core._growth import TreeStructure
 from .._core._tree import fit_tree
 from .._loss import LossFunction, get_loss_function
@@ -145,19 +150,8 @@ class DART(PersistenceMixin):
         state = TrainingState(model=self, n_rounds=self.n_trees)
         cb_manager.on_train_begin(state)
 
-        # Warn if EarlyStopping without eval_set
         eval_set = validate_eval_set(eval_set, self.X_binned_.n_features)
-        if eval_set is None:
-            for cb in (callbacks or []):
-                if isinstance(cb, EarlyStopping):
-                    warnings.warn(
-                        "EarlyStopping callback provided but eval_set is None. "
-                        "Early stopping requires eval_set to compute validation "
-                        "loss and will have no effect.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    break
+        warn_if_early_stopping_without_eval_set(callbacks, eval_set)
 
         # Train trees
         for _i in range(self.n_trees):

--- a/src/openboost/_models/_distributional.py
+++ b/src/openboost/_models/_distributional.py
@@ -41,7 +41,12 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 
 from .._array import BinnedArray, array
-from .._callbacks import Callback, CallbackManager, EarlyStopping, TrainingState
+from .._callbacks import (
+    Callback,
+    CallbackManager,
+    TrainingState,
+    warn_if_early_stopping_without_eval_set,
+)
 from .._core._growth import TreeStructure
 from .._core._tree import fit_tree
 from .._distributions import (
@@ -172,17 +177,7 @@ class DistributionalGBDT(PersistenceMixin):
         cb_manager.on_train_begin(state)
 
         eval_set = validate_eval_set(eval_set, self.X_binned_.n_features)
-        if eval_set is None:
-            for cb in (callbacks or []):
-                if isinstance(cb, EarlyStopping):
-                    warnings.warn(
-                        "EarlyStopping callback provided but eval_set is None. "
-                        "Early stopping requires eval_set to compute validation "
-                        "loss and will have no effect.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    break
+        warn_if_early_stopping_without_eval_set(callbacks, eval_set)
 
         # Training loop
         for _round_idx in range(self.n_trees):


### PR DESCRIPTION
## Summary
Fixes the issues surfaced in code review of the recent `feat: 12 UX improvements` and `fix: correctness/safety` commits:

- **Categorical auto-detection bug:** `dtype is object` is always `False` for pandas/numpy object columns (`np.dtype('O') is object` → `False`), so string columns were silently *not* detected. Now tested via `dtype.kind in ('O','U','S')` (+ `categories` for pandas Categorical). Numpy object **and** string arrays now work.
- **`clear_tree_workspace_cache()` unreachable:** was defined only in `_backends/_cuda.py` and never exported (and unsafe to import on CPU-only installs). Added a backend-dispatching wrapper with a **CPU no-op** and exported it as `openboost.clear_tree_workspace_cache`.
- **Categorical bitset ≥64 safety:** the prior fix guarded only the CPU partition path. Confirmed the GPU partition kernel is ordinal-only (no bitset), then capped the remaining 5 `1 << cat` / `bitset >> bin` sites — both CPU+GPU split-finders skip bits ≥64 and all three predict paths route bins ≥64 right. Categories with bin ≥64 now consistently go right everywhere (documented).
- **`backend_context` docs:** clarified it mutates a process-global (not thread-local) backend; documented the intentional `None`→auto-detect restore.
- **DRY:** extracted `warn_if_early_stopping_without_eval_set()` into `_callbacks.py`, removing 5 duplicated warning blocks across GradientBoosting / MultiClass / DART / NaturalBoost.

## Test plan
- [x] `ruff check src/openboost/` — no new errors (2 remaining `SIM108` are pre-existing in unrelated CUDA kernels)
- [x] Full CPU suite: `OPENBOOST_BACKEND=cpu uv run pytest tests/` → **511 passed, 25 skipped**
- [x] Smoke: object-array categorical auto-detect, numeric arrays unaffected, `clear_tree_workspace_cache()` CPU no-op, EarlyStopping-without-eval_set warning fires
- [x] 100-category (>64) feature trains + predicts deterministically/consistently
- [x] `py_compile` on all edited files (syntax-checks the `@cuda.jit` kernels, which can't JIT without a GPU)

Made with [Cursor](https://cursor.com)